### PR TITLE
Allow disabling SemVerTagNameFilter

### DIFF
--- a/internal/gcrgc/filters.go
+++ b/internal/gcrgc/filters.go
@@ -174,6 +174,10 @@ func NewSemVerTagNameFilter(enabled bool) *SemVerTagNameFilter {
 
 // Apply returns true if if no tag was in the exclusion list.
 func (f *SemVerTagNameFilter) Apply(img *docker.Image) bool {
+	if !f.enabled {
+		// Filter is disabled, image is eligible for deletion.
+		return true
+	}
 
 	return !img.HasTagRegexp(f.regex)
 }

--- a/internal/gcrgc/filters_test.go
+++ b/internal/gcrgc/filters_test.go
@@ -197,6 +197,7 @@ func TestFilterImages(t *testing.T) {
 		filters := []ImageFilter{
 			UntaggedFilter{false},
 			TagNameFilter{[]string{"latest"}},
+			NewSemVerTagNameFilter(false),
 			NewTagNameRegexFilter([]string{"^(dev-)?[0-9]\\.[0-9]-(cli|fpm)$"}),
 		}
 


### PR DESCRIPTION
With the default configuration of gcrgc the semver tags are ignored. Setting `--exclude-semver-tags` to false explicitly has no effect.

`SemVerTagNameFilter.Apply()` doesn't check if the filter was enabled and gets applied always. This change adds a check which allows disabling SemVerTagNameFilter, making the default configuration of gcrgc to delete semver tags as well.
Based on the similar check in `UntaggedFilter`.
Updated an existing test that uses a disabled `UntaggedFilter` to also have a disabled `SemVerTagNameFilter` to verify the fix.